### PR TITLE
Fix:FileInfo中filename，path，basePath其中任意一个为Null的情况下会导致文件获取异常null字符串的出现

### DIFF
--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/FileInfo.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/FileInfo.java
@@ -161,4 +161,48 @@ public class FileInfo implements Serializable {
     private Date createTime;
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * 获取文件全路径（相对路径）
+     *
+     * @param fileInfo 文件信息
+     * @return {@link String} 返回带文件名的全路径（相对路径）
+     */
+    public String getFilePath(FileInfo fileInfo) {
+        StringBuilder basePathStringBuilder = getBasePathStringBuilder(fileInfo);
+        if (null != fileInfo.getFilename()) {
+            basePathStringBuilder.append(fileInfo.getFilename());
+        }
+        return basePathStringBuilder.toString();
+    }
+    /**
+     * 获取缩略图全路径（相对路径）
+     *
+     * @param fileInfo 文件信息
+     * @return {@link String} 返回带文件名的全路径（相对路径）
+     */
+    public String getThFilePath(FileInfo fileInfo) {
+        StringBuilder basePathStringBuilder = getBasePathStringBuilder(fileInfo);
+        if (null != fileInfo.getThFilename()) {
+            basePathStringBuilder.append(fileInfo.getThFilename());
+        }
+        return basePathStringBuilder.toString();
+    }
+
+    /**
+     * 获取基本路径StringBuilder
+     *
+     * @param fileInfo 文件信息
+     * @return {@link StringBuilder}
+     */
+    private StringBuilder getBasePathStringBuilder(FileInfo fileInfo) {
+        StringBuilder filePathBuilder = new StringBuilder();
+        if (null != fileInfo.getBasePath()) {
+            filePathBuilder.append(fileInfo.getBasePath());
+        }
+        if (null != fileInfo.getPath()) {
+            filePathBuilder.append(fileInfo.getPath());
+        }
+        return filePathBuilder;
+    }
 }

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/AliyunOssFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/AliyunOssFileStorage.java
@@ -65,12 +65,13 @@ public class AliyunOssFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/AmazonS3FileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/AmazonS3FileStorage.java
@@ -66,12 +66,12 @@ public class AmazonS3FileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/AzureBlobFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/AzureBlobFileStorage.java
@@ -107,12 +107,12 @@ public class AzureBlobFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/BaiduBosFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/BaiduBosFileStorage.java
@@ -70,12 +70,12 @@ public class BaiduBosFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/FtpFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/FtpFileStorage.java
@@ -61,12 +61,12 @@ public class FtpFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     /**

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/GoogleCloudStorageFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/GoogleCloudStorageFileStorage.java
@@ -71,12 +71,12 @@ public class GoogleCloudStorageFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/HuaweiObsFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/HuaweiObsFileStorage.java
@@ -69,12 +69,12 @@ public class HuaweiObsFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/LocalFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/LocalFileStorage.java
@@ -53,12 +53,13 @@ public class LocalFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getPath() + fileInfo.getFilename();
+        fileInfo.setBasePath(null);
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
-        if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getPath() + fileInfo.getThFilename();
+        fileInfo.setBasePath(null);
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/LocalPlusFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/LocalPlusFileStorage.java
@@ -55,12 +55,12 @@ public class LocalPlusFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/MinioFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/MinioFileStorage.java
@@ -70,12 +70,12 @@ public class MinioFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/QiniuKodoFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/QiniuKodoFileStorage.java
@@ -59,12 +59,12 @@ public class QiniuKodoFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/SftpFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/SftpFileStorage.java
@@ -65,12 +65,12 @@ public class SftpFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     /**

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/TencentCosFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/TencentCosFileStorage.java
@@ -66,12 +66,12 @@ public class TencentCosFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/UpyunUssFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/UpyunUssFileStorage.java
@@ -70,12 +70,12 @@ public class UpyunUssFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     @Override

--- a/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/WebDavFileStorage.java
+++ b/x-file-storage-core/src/main/java/org/dromara/x/file/storage/core/platform/WebDavFileStorage.java
@@ -54,12 +54,12 @@ public class WebDavFileStorage implements FileStorage {
     }
 
     public String getFileKey(FileInfo fileInfo) {
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getFilename();
+        return fileInfo.getFilePath(fileInfo);
     }
 
     public String getThFileKey(FileInfo fileInfo) {
         if (StrUtil.isBlank(fileInfo.getThFilename())) return null;
-        return fileInfo.getBasePath() + fileInfo.getPath() + fileInfo.getThFilename();
+        return fileInfo.getThFilePath(fileInfo);
     }
 
     /**


### PR DESCRIPTION
当自定义FileInfo时，一般项目上只存文件相对路径与UUID的对应关系，此次修复内容主要解决了filename，path，basePath，任意一个不赋值时无法读取远程文件的问题